### PR TITLE
Fix link in `README.md` that points to wrong repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A CRAN-like package repository for previously released R packages originating fr
 The following releases are available in this repository:
 
 - [2022_06_09](./2022_06_09/src/contrib/)
-- [2022_10_13](./2022_06_09/src/contrib/)
+- [2022_10_13](./2022_10_13/src/contrib/)
 
 Set the repository options in R to point to a specific release in this repository:
 


### PR DESCRIPTION
`2022_10_13` is actually linking the June repository